### PR TITLE
fix process.hrtime issue with integer overflows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,11 @@ readdir(__dirname)
         continue;
       }
 
-      const startDay = process.hrtime();
+      const startDay = process.hrtime.bigint();
       const [module, input] = modAndInputs[i];
       const [p1, p2] = module.default(input);
-      const time = process.hrtime(startDay)[1] / 1000000;
+      const endDay = process.hrtime.bigint();
+      const time = Number(endDay - startDay) / 1e6;
       totalTime += time;
 
       console.info(`======== Day ${i} ========`);


### PR DESCRIPTION
`process.hrtime()` is deprecated and in this particular case was causing issues for days that take over 1073741824 (`1 << 31`) nanoseconds to finish, leading to the wrong times being reported.

This PR uses `process.hrtime.bigint()` instead.